### PR TITLE
Update method _postprocess_view of ir_ui_view by removing the input a…

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_ui_view.py
+++ b/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_ui_view.py
@@ -46,10 +46,10 @@ def _raise_view_error(
             self.write({"active": False})
 
 
-def _postprocess_view(self, node, model, validate=True, editable=True):
+def _postprocess_view(self, node, model, editable=True):
     """Don't validate views, _raise_view_error is mutted"""
     return View._postprocess_view._original_method(
-        self, node, model, validate=False, editable=editable
+        self, node, model, editable=editable
     )
 
 


### PR DESCRIPTION
…rg validate as it is not anymore in odoo 15

Fixed Error:

`TypeError: _postprocess_view() got an unexpected keyword argument 'validate'`